### PR TITLE
Fix: add uppercase authentication header key

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -52,7 +52,9 @@ export const api = {
       email: email,
       password: password,
     });
-    return response.headers["authentication"];
+    return (
+      response.headers["authentication"] || response.headers["Authentication"]
+    );
   },
   _signup: async (username: string, email: string, password: string) => {
     const response = await instance.post<UserInfoResponse>(
@@ -64,7 +66,9 @@ export const api = {
       }
     );
     return {
-      token: response.headers["authentication"],
+      token:
+        response.headers["authentication"] ||
+        response.headers["Authentication"],
       userInfo: response.data,
     };
   },


### PR DESCRIPTION
preflight 이후 POST를 날리면 `authentication` 헤더의 키가 `Authentication`으로 나타나는 문제 해결.