### PR TITLE
fix: extend question summary length

### DIFF
--- a/src/pages/Questions/QuestionItem/QuestionItem.tsx
+++ b/src/pages/Questions/QuestionItem/QuestionItem.tsx
@@ -10,11 +10,13 @@ interface QuestionItemProps {
   question: QuestionInterface;
 }
 
+const MAXIMUM_SUMMARY_LENGTH = 200;
+
 const useQuestionSummary = (markdown: string) => {
   return useMemo(() => {
     const pureText = RemoveMarkdown(markdown);
-    return pureText.length > 100
-      ? pureText.substring(0, 100) + "..."
+    return pureText.length > MAXIMUM_SUMMARY_LENGTH
+      ? pureText.substring(0, MAXIMUM_SUMMARY_LENGTH) + "..."
       : pureText;
   }, [markdown]);
 };


### PR DESCRIPTION
* questions 페이지에 나타나는 요약의 길이를 100에서 200으로 늘렸습니다.