### PR TITLE
fix: questions sort-by-votes order reversed

### DIFF
--- a/src/pages/Questions/Questions.tsx
+++ b/src/pages/Questions/Questions.tsx
@@ -12,7 +12,7 @@ import styles from "./Questions.module.scss";
 
 const FILTERS: { label: string; criteria: SortCriteria; order: SortOrder }[] = [
   { label: "Newest", criteria: "createdAt", order: "desc" },
-  { label: "Votes", criteria: "voteCount", order: "asc" },
+  { label: "Votes", criteria: "voteCount", order: "desc" },
 ];
 
 const makePageList = (


### PR DESCRIPTION
*  Questions의 Votes 순 정렬이 거꾸로 되어있던 것을 수정했습니다.