### PR TITLE
fix: change profile page css class name

### DIFF
--- a/src/pages/MyPage/MyInfo/MyInfo.tsx
+++ b/src/pages/MyPage/MyInfo/MyInfo.tsx
@@ -11,7 +11,7 @@ interface MyInfoProps {
 
 const MyInfo: FC<MyInfoProps> = ({ userInfo }) => {
   return userInfo ? (
-    <div className={styles.myInfo}>
+    <div className={styles.userInfo}>
       <img
         className={styles.profileImg}
         src={dummyProfile}

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -77,7 +77,7 @@ const MyPage: FC<MyPageProps> = () => {
   }, [navigate, refreshUserInfo]);
 
   return userInfo ? (
-    <div className={styles.myPage}>
+    <div className={styles.userPage}>
       {me && <ProfileButtons />}
       <MyInfo userInfo={userInfo} />
       <MyPageTab mode={tab} me={me} />


### PR DESCRIPTION
* 프로필 페이지의 바뀐 css 클래스명이 컴포넌트의 `className`에 제대로 적용되지 않았던 문제를 해결했습니다.